### PR TITLE
Incremental Work

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,25 @@ StepManiaX SDK for Python
 Currently fairly incomplete. A lot of core functionality exists, but the rest of the SDK needs to be finished. At some point I can write out a list
 of functions currently enabled and which ones have yet to be added.
 
+
+### Ported Functions
+
+- Get Device Info: Get basic stage information such as Player jumper, serial number, firmware version
+- Get Config v5: Get the stage configuration (version 5 and up)
+- Write Config v5: Write the stage configuration (version 5 and up)
+- Factory Reset: Factory reset the stage to original settings
+- Set Light Strip: Set the color of the underglow light strips (Currently only used in factory\_reset function)
+- Force Recalibration: Force the stage to perform a recalibration
+- Get Sensor Test Data: Get sensor test data for modes [uncalibrated, calibrated, noise, tare]
+- Set Serial Numbers: Sets a stage serial if it doesn't exist yet. Does nothing if one exists
+- Set Panel Test Mode: Turn on/off panel test mode
+
+### Functions Left to Port
+
+- Set Lights: Set panel lights (This seems fairly complicated at a quick glance)
+- Upload GIF Data: Upload GIF Data to Panels
+- Re-Enable Auto Lights: Assume this just turns auto GIFs on the pads back on to default?
+
 ## Installation (macOS)
 
 These are the instructions that I have been using to run this on my system so far.

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ of functions currently enabled and which ones have yet to be added.
 
 ### Functions Left to Port
 
+- Get Config <v5: Get the stage configuration (version 4 and lower)
+- Write Config <v5: Write the stage configuration (version 4 and lower)
 - Set Lights: Set panel lights (This seems fairly complicated at a quick glance)
 - Upload GIF Data: Upload GIF Data to Panels
 - Re-Enable Auto Lights: Assume this just turns auto GIFs on the pads back on to default?

--- a/pysmx/sdk/config.py
+++ b/pysmx/sdk/config.py
@@ -76,8 +76,8 @@ class PackedSensorSettings(object):
 
 @dataclass
 class SMXConfigFlags(object):
-    # If set, the panels will use the pressed animation when pressed, and step_color is ignored.
-    # If unset, panels will be lit solid using step_color.
+    # If True, the panels will use the pressed animation when pressed, and step_color is ignored.
+    # If False, panels will be lit solid using step_color.
     # master_version >= 4. Previous versions always use step_color.
     auto_lighting_use_pressed_animations: bool = True
 

--- a/pysmx/sdk/config.py
+++ b/pysmx/sdk/config.py
@@ -13,6 +13,7 @@ class PackedSensorSettings(object):
     fsr_low_threshold: list[int]  # 4 values
     fsr_high_threshold: list[int]  # 4 values
 
+    # TODO: Figure out what this is for
     combined_low_threshold: int
     combined_high_threshold: int
 

--- a/pysmx/sdk/packets.py
+++ b/pysmx/sdk/packets.py
@@ -206,6 +206,7 @@ def send_packets(
             # If we are expecting an acknowledgement, check if the raw_data is equal to
             # an acknowledgemenet packet
             if acknowledge and raw_data == ACK_PACKET:
+                logger.debug("Successfully Acknowledged")
                 break
 
             # Else we parse the packet until it is finished

--- a/pysmx/sdk/sensors.py
+++ b/pysmx/sdk/sensors.py
@@ -29,6 +29,7 @@ class PanelTestMode(BytesEnum):
     PRESSURE_TEST = b"1"
 
 
+# TODO: This might be backwards?
 class Panel(IntEnum):
     DOWN_LEFT = 0
     DOWN = 1

--- a/set_stage_configs.py
+++ b/set_stage_configs.py
@@ -103,8 +103,7 @@ def make_new_config(player: int, old_config: SMXStageConfig) -> SMXStageConfig:
     config.platform_strip_color = [int(x * brightness) for x in platform_strip_color]
     config.auto_light_panel_mask = auto_light_mask
     if step_color:
-        # Enable flags to use step color
-        config.flags &= ~(1 << 0)
+        config.flags.auto_lighting_use_pressed_animations = False
         config.step_color = step_color
     config.panel_settings = panel_settings
 

--- a/testing.py
+++ b/testing.py
@@ -1,0 +1,13 @@
+from pysmx.sdk.api import SMXAPI
+from pysmx.sdk.sensors import PanelTestMode
+
+
+x = SMXAPI()
+
+x._find_stages()
+
+x.set_panel_test_mode(1, PanelTestMode.PRESSURE_TEST)
+
+import pdb
+
+pdb.set_trace()


### PR DESCRIPTION
- Added `set_serial_numbers` function that will add a serial number to a stage if one does not exist. Honestly this probably doesn't need this function to exist, it's probably run at the factory.
- Added `set_panel_test_mode`. When sending the command it seems to do *something* but pressing on the panels doesn't light anything up, so I'm not too sure what's wrong yet.
- Move SMXConfig Flags to its own object so you can get and set the flags much more easily. 
- Add a little `testing.py` script that you can run in the venv which will set up the API and drop you into a debugger. 